### PR TITLE
Bumps version of node to fix webpack-cli dependency

### DIFF
--- a/pkgs/available/nodejs.sh
+++ b/pkgs/available/nodejs.sh
@@ -1,4 +1,4 @@
-NODEJS_VERSION="6.11.2"
+NODEJS_VERSION="6.11.5"
 
 getpkg https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}.tar.gz
 tar zxf node-v${NODEJS_VERSION}.tar.gz


### PR DESCRIPTION
webpack's cli got split into webpack-cli, which requires node 6.11.5